### PR TITLE
add FrozenDict type

### DIFF
--- a/src/arctictypes/__init__.py
+++ b/src/arctictypes/__init__.py
@@ -18,12 +18,14 @@ from importlib.metadata import version
 
 from ._internal._converters import STANDARD_CONVERTERS, Converter
 from ._internal.freeze import ConverterNotFoundError, freeze
+from ._internal.frozendict import FrozenDict
 
 __all__ = [
     "ConverterNotFoundError",
     "freeze",
     "STANDARD_CONVERTERS",
     "Converter",
+    "FrozenDict",
 ]
 
 __version__ = version(__package__)

--- a/src/arctictypes/_internal/_converters/standard.py
+++ b/src/arctictypes/_internal/_converters/standard.py
@@ -18,14 +18,13 @@ import collections
 from collections.abc import Iterable, Mapping, Sequence
 from typing import Callable, Final
 
-import immutabledict
-
 from arctictypes._internal._converters.base import (
     STANDARD_MUTABLE_PRIORITY,
     STANDARD_NON_PRIMITIVE_IMMUTABLE_PRIORITY,
     STANDARD_PRIMITIVE_PRIORITY,
     Converter,
 )
+from arctictypes._internal.frozendict import FrozenDict
 
 STANDARD_PRIMITIVE_TYPES: Final = (str, int, float, bool, type(None))
 
@@ -46,11 +45,9 @@ def convert_set_like(obj: Iterable, freeze_child: Callable) -> set:
     return set(freeze_child(child) for child in obj)
 
 
-def convert_mapping(
-    obj: Mapping, freeze_child: Callable
-) -> immutabledict.immutabledict:
+def convert_mapping(obj: Mapping, freeze_child: Callable) -> FrozenDict:
     """A convert a mapping object."""
-    return immutabledict.immutabledict(
+    return FrozenDict(
         {freeze_child(key): freeze_child(value) for key, value in obj.items()}
     )
 
@@ -68,7 +65,7 @@ STANDARD_NON_PRIMITIVE_IMMUTABLE_CONVERTERS: Final[Sequence[Converter]] = (
         priority=STANDARD_NON_PRIMITIVE_IMMUTABLE_PRIORITY,
     ),
     Converter(
-        input_type=immutabledict.immutabledict,
+        input_type=FrozenDict,
         convert=convert_mapping,
         priority=STANDARD_NON_PRIMITIVE_IMMUTABLE_PRIORITY,
     ),

--- a/src/arctictypes/_internal/frozendict.py
+++ b/src/arctictypes/_internal/frozendict.py
@@ -14,9 +14,11 @@
 
 """An implementation of a frozen dictionary with support for pydantic."""
 
+from __future__ import annotations
+
 import typing
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, TypeVar, overload
 
 from immutabledict import immutabledict
 from pydantic import GetCoreSchemaHandler
@@ -32,6 +34,15 @@ _V_co = TypeVar("_V_co", covariant=True)
 
 class FrozenDict(immutabledict[_K, _V_co]):
     """A pydantic-comatible wrapper around immutabledict."""
+
+    @overload
+    def __new__(cls, arg: Mapping[_K, _V_co]) -> FrozenDict[_K, _V_co]: ...
+
+    @overload
+    def __new__(cls, **kwargs: _V_co) -> FrozenDict[str, _V_co]: ...
+
+    def __new__(cls, *args: Any, **kwargs: Any) -> FrozenDict:
+        return super().__new__(cls, *args, **kwargs)  # type: ignore
 
     @classmethod
     def __get_pydantic_core_schema__(

--- a/src/arctictypes/_internal/frozendict.py
+++ b/src/arctictypes/_internal/frozendict.py
@@ -1,0 +1,67 @@
+# Copyright 2024 Kersten Henrik Breuer
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""An implementation of a frozen dictionary with support for pydantic."""
+
+import typing
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from immutabledict import immutabledict
+from pydantic import GetCoreSchemaHandler
+from pydantic_core.core_schema import (
+    CoreSchema,
+    no_info_after_validator_function,
+    plain_serializer_function_ser_schema,
+)
+
+_K = TypeVar("_K")
+_V_co = TypeVar("_V_co", covariant=True)
+
+
+class FrozenDict(immutabledict[_K, _V_co]):
+    """A pydantic-comatible wrapper around immutabledict."""
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, source: Any, handler: GetCoreSchemaHandler
+    ) -> CoreSchema:
+        """Get the pydantic core schema for this type."""
+        # Validate the type against a Mapping:
+        args = typing.get_args(source)
+        if not args:
+            validation_schema = handler.generate_schema(Mapping)
+            return_schema = handler.generate_schema(dict)
+        elif len(args) == 2:
+            validation_schema = handler.generate_schema(Mapping[args[0], args[1]])  # type: ignore
+            return_schema = handler.generate_schema(dict[args[0], args[1]])  # type: ignore
+        else:
+            raise TypeError(
+                "Expected exactly two (or no) type arguments for FrozenDict, got"
+                + f" {len(args)}"
+            )
+
+        serialization_schema = plain_serializer_function_ser_schema(
+            lambda x: dict(x), return_schema=return_schema
+        )
+
+        # Uses cls as validator function to convert the dict to a FrozenDict:
+        return no_info_after_validator_function(
+            # callable to use after validation against the schema (convert to
+            # FrozenDict):
+            cls,
+            # the validation schema to use before executing the callable:
+            validation_schema,
+            serialization=serialization_schema,
+        )

--- a/tests/cases.py
+++ b/tests/cases.py
@@ -17,8 +17,7 @@
 from dataclasses import dataclass
 from typing import Any
 
-from arctictypes import ConverterNotFoundError
-from immutabledict import immutabledict
+from arctictypes import ConverterNotFoundError, FrozenDict
 
 
 @dataclass(frozen=True)
@@ -45,7 +44,7 @@ SEQUENCE_OF_PRIMITIVES_EXAMPLE = (1, "hello", True, None, b"hello")
 MAPPING_OF_PRIMITIVES_EXAMPLE = {
     value: value for value in SEQUENCE_OF_PRIMITIVES_EXAMPLE
 }
-NESTED_IMMUTABLE_EXAMPLE: Any = immutabledict(
+NESTED_IMMUTABLE_EXAMPLE: Any = FrozenDict(
     {"a": tuple(frozenset(SEQUENCE_OF_PRIMITIVES_EXAMPLE))}
 )
 
@@ -83,9 +82,9 @@ VALID_CASES = (
         expected_outputs=(),
     ),
     ValidTestCase(
-        name="empty_immutabledict",
-        inputs=immutabledict(),
-        expected_outputs=immutabledict(),
+        name="empty_FrozenDict",
+        inputs=FrozenDict(),
+        expected_outputs=FrozenDict(),
     ),
     ValidTestCase(
         name="empty_frozenset",
@@ -100,7 +99,7 @@ VALID_CASES = (
     ValidTestCase(
         name="empty_dict",
         inputs={},
-        expected_outputs=immutabledict(),
+        expected_outputs=FrozenDict(),
     ),
     ValidTestCase(
         name="empty_set",
@@ -114,9 +113,9 @@ VALID_CASES = (
         expected_outputs=tuple(SEQUENCE_OF_PRIMITIVES_EXAMPLE),
     ),
     ValidTestCase(
-        name="immutabledict_of_primitives",
-        inputs=immutabledict(MAPPING_OF_PRIMITIVES_EXAMPLE),
-        expected_outputs=immutabledict(MAPPING_OF_PRIMITIVES_EXAMPLE),
+        name="FrozenDict_of_primitives",
+        inputs=FrozenDict(MAPPING_OF_PRIMITIVES_EXAMPLE),
+        expected_outputs=FrozenDict(MAPPING_OF_PRIMITIVES_EXAMPLE),
     ),
     ValidTestCase(
         name="frozenset_of_primitives",
@@ -132,7 +131,7 @@ VALID_CASES = (
     ValidTestCase(
         name="dict_of_primitives",
         inputs=dict(MAPPING_OF_PRIMITIVES_EXAMPLE),
-        expected_outputs=immutabledict(MAPPING_OF_PRIMITIVES_EXAMPLE),
+        expected_outputs=FrozenDict(MAPPING_OF_PRIMITIVES_EXAMPLE),
     ),
     ValidTestCase(
         name="set_of_primitives",
@@ -152,7 +151,7 @@ VALID_CASES = (
     ),
     ValidTestCase(
         name="nested_immutable_parent_mutable_children",
-        inputs=immutabledict({"a": list(set(SEQUENCE_OF_PRIMITIVES_EXAMPLE))}),
+        inputs=FrozenDict({"a": list(set(SEQUENCE_OF_PRIMITIVES_EXAMPLE))}),
         expected_outputs=NESTED_IMMUTABLE_EXAMPLE,
     ),
     ValidTestCase(

--- a/tests/test_frozendict.py
+++ b/tests/test_frozendict.py
@@ -16,7 +16,7 @@
 
 import json
 
-from arctictypes._internal.frozendict import FrozenDict
+from arctictypes import FrozenDict
 from pydantic import BaseModel, ConfigDict
 
 

--- a/tests/test_frozendict.py
+++ b/tests/test_frozendict.py
@@ -1,0 +1,93 @@
+# Copyright 2024 Kersten Henrik Breuer
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test the FrozenDict class."""
+
+from arctictypes._internal.frozendict import FrozenDict
+from pydantic import BaseModel, ConfigDict
+
+
+def test_frozen_dict():
+    """Test validation and serialization of FrozenDict used in pydantic models.."""
+
+    class Test(BaseModel):
+        dict_: FrozenDict
+
+    test_dict = {1: 2}
+
+    test_from_dict = Test.model_validate({"dict_": test_dict})
+    test_from_frozendict = Test(dict_=FrozenDict(test_dict))
+
+    assert test_from_dict.dict_ == test_from_frozendict.dict_ == FrozenDict(test_dict)
+
+    test_dumped = test_from_dict.model_dump()
+    observed_dict = test_dumped["dict_"]
+    assert observed_dict == test_dict
+    assert isinstance(observed_dict, dict)
+
+
+def test_frozen_dict_schema():
+    """Test JSON schema generation of FrozenDicts-containing pydantic models."""
+
+    class Test(BaseModel):
+        dict_: FrozenDict
+
+    schema_from_frozendict = Test.model_json_schema()
+
+    # redefine Test to not using standard dict:
+    class Test(BaseModel):  # type: ignore
+        dict_: dict
+
+    schema_from_dict = Test.model_json_schema()
+
+    assert schema_from_frozendict == schema_from_dict
+
+
+def test_frozen_dict_hashing():
+    """Test hashing and comparison of pydantic models using FrozenDicts."""
+
+    class Test(BaseModel):
+        dict_: FrozenDict
+
+        model_config = ConfigDict(frozen=True)
+
+    test_dict = {1: 2}
+
+    test1 = Test.model_validate({"dict_": test_dict})
+    test2 = Test.model_validate({"dict_": test_dict})
+
+    # make sure hash does not throw an exception
+    hash(test1)
+
+    assert test1 == test2
+
+
+def test_frozen_dict_nesting():
+    """Test nested pydantic models using FrozenDict."""
+
+    class Inner(BaseModel):
+        dict_: FrozenDict
+
+    class Test(BaseModel):
+        inner: FrozenDict[str, Inner]
+
+    test_dict = {1: 2}
+
+    test1 = Test.model_validate({"inner": {"test": {"dict_": test_dict}}})
+    assert isinstance(test1.inner["test"], Inner)
+
+    test2 = Test(
+        inner=FrozenDict({"test": FrozenDict({"dict_": FrozenDict(test_dict)})})
+    )
+    assert test1 == test2


### PR DESCRIPTION
```
Added a Mapping type that does not provide any additional methods for modification of
its content after construction.

It has first class support for type hints. Moreover, it is ready to be used in
Pydantic v2 models, yet, does not require Pydantic as a dependency.
```